### PR TITLE
Update ESLMapVisualization.class.st

### DIFF
--- a/src/Football-Roassal/ESLMapVisualization.class.st
+++ b/src/Football-Roassal/ESLMapVisualization.class.st
@@ -38,8 +38,7 @@ ESLMapVisualization >> defaultContainer [
 	^ RSCanvas new @ (RSCanvasController new
 		in: [ :controller|
 			controller configuration 
-				noLegend;
-				useZoomToFitOnExtendChanged.
+				noLegend.
 			 ];
 		yourself)
 		


### PR DESCRIPTION
useZoomToFitOnExtendChanged (sic) does not apply to configuration. This fixes a bug on install in Pharo 11.